### PR TITLE
Hollow Knight, Haiku & Shadu-Multiworld

### DIFF
--- a/src/series/Haiku,_the_Robot.yml
+++ b/src/series/Haiku,_the_Robot.yml
@@ -8,3 +8,4 @@ randomizers:
     url: https://github.com/Jarlyk/Haiku.Rando
     comment: Requires [Haiku.CoreModdingApi](https://github.com/Jarlyk/Haiku.ModdingApi)
         and [BepInEx](https://github.com/BepInEx/BepInEx)
+    multiworld: Shadu-Multiworld

--- a/src/series/Hollow_Knight.yml
+++ b/src/series/Hollow_Knight.yml
@@ -1,15 +1,21 @@
 name: Hollow Knight
-comment: 'Support is available on the [official Hollow Knight Discord server](https://discord.com/invite/hollowknight)
-    in the #randomizer channel.'
+comment: |-
+    Use [Lumafly](https://themulhima.github.io/Lumafly/) for easy installation & updates.
+
+    Support is available on the [official Hollow Knight Discord server](https://discord.com/invite/hollowknight) in the #randomizer channel.
 sub-series: null
 randomizers:
 -   games:
     - Hollow Knight
     identifier: Randomizer 4
     url: https://github.com/homothetyhk/RandomizerMod
-    comment: '[Multiplayer add-on](https://github.com/Shadudev/HollowKnight.MultiWorld)
-        - Mod manager [Scarab](https://github.com/fifty-six/Scarab) for easy installation
-        and updates'
+    comment: Find add-ons through Lumafly's `Advanced Search > Search by Dependencies & Integrations` with the term `Randomizer 4`.
+-   games: 
+    - Hollow Knight
+    identifier: Multiworld
+    url: https://github.com/Shadudev/HollowKnight.MultiWorld
+    multiworld: Shadu-Multiworld
+    comment: Requires Randomizer 4. Also see Itemsync in the same repo or on Lumafly.
 -   games:
     - Hollow Knight
     identifier: Archipelago

--- a/src/series/Multi-series.yml
+++ b/src/series/Multi-series.yml
@@ -71,6 +71,13 @@ randomizers:
     sub-series: Connected worlds
     comment: List of [additional extensions in development](https://multiworld.news/apworlds.html)
 -   games:
+        - Hollow Knight
+        - Haiku, the Robot
+    identifier: Shadu's Multiworld
+    url: https://github.com/Shadudev/HollowKnight.MultiWorld
+    multiworld: Shadu-Multiworld
+    sub-series: Connected worlds
+-   games:
     - 'Castlevania: Harmony of Dissonance'
     - Bomberman Tournament
     identifier: HoDBT


### PR DESCRIPTION
Multi-Series: Add Shadu-Multiworld, a game-agnostic multiworld server.

Hollow Knight: Reflect switch to Lumafly mod installer, clearly separate Shadu-Multiworld but with note about Rando 4 dependency.

Haiku, The Robot: Reflect Shadu-Multiworld compatibility.