### PR TITLE
Icons

### DIFF
--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -1,4 +1,4 @@
-<h3 id="{{ include.series.name }}"><a href="#{{ include.series.name }}">🔗</a> {{ include.series.name }}</h3>
+<h3 id="{{ include.series.name }}" class="my-0"><a href="#{{ include.series.name }}"><i class="bi bi-link-45deg"></i></a> {{ include.series.name }}</h3>
 
 {%- if include.series.comment -%}
     <p>{{ include.series.comment | markdownify }}</p>

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -18,6 +18,9 @@ const setTheme = theme => {
 
     let opposite = (theme == 'dark') ? 'light' : 'dark';
     $("#themeSwitch").addClass('btn-' + opposite).removeClass('btn-' + theme);
+    let icon = (theme == 'dark') ? 'sun' : 'moon';
+    let oppositeIcon = (theme == 'dark') ? 'moon' : 'sun';
+    $("#themeSwitch > i").addClass('bi-' + icon).removeClass('bi-' + oppositeIcon)
 }
 
 window.addEventListener('DOMContentLoaded', () => {

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -14,14 +14,11 @@ const getPreferredTheme = () => {
 }
 
 const setTheme = theme => {
-    if (theme === 'auto') {
-    document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
-    } else {
-    document.documentElement.setAttribute('data-bs-theme', theme)
-    }
-}
+    document.documentElement.setAttribute('data-bs-theme', theme);
 
-setTheme(getPreferredTheme())
+    let opposite = (theme == 'dark') ? 'light' : 'dark';
+    $("#themeSwitch").addClass('btn-' + opposite).removeClass('btn-' + theme);
+}
 
 window.addEventListener('DOMContentLoaded', () => {
     setTheme(getPreferredTheme())
@@ -29,12 +26,12 @@ window.addEventListener('DOMContentLoaded', () => {
 
 document.getElementById("themeSwitch").addEventListener("click", () => {
     if (document.documentElement.getAttribute('data-bs-theme') == 'dark') {
-    setTheme("light")
-    setStoredTheme("light")
+        setTheme("light")
+        setStoredTheme("light")
     }
     else {
-    setTheme("dark")
-    setStoredTheme("dark")
+        setTheme("dark")
+        setStoredTheme("dark")
     }
 });
 

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8" />
     <title>The BIG List of Video Game Randomizers</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <style>
       body {
         font-family: sans-serif;
@@ -29,24 +30,33 @@
         Latest revision: {{ site.time | date: '%d %B, %Y' }}
       </div>
       <div class="d-flex justify-content-center gap-2">
-        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#aboutModal">About</button>
-        <a class="btn btn-outline-success" href="https://discord.com/invite/YREMzGQ3gd">Discord</a>
-        <a class="btn btn-outline-success" href="https://github.com/video-game-randomizers/rando-list">GitHub</a>
-        <button class="btn btn-secondary" id="themeSwitch">Toggle Theme</button>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#aboutModal"><i class="bi bi-info-circle"></i> About</button>
+        <div class="btn-group" role="group" aria-label="External Links">
+          <a class="btn btn-outline-success" href="https://discord.com/invite/YREMzGQ3gd" aria-label="Discord"><i class="bi bi-discord" aria-hidden="true"></i></a>
+          <a class="btn btn-outline-success" href="https://github.com/video-game-randomizers/rando-list" aria-label="GitHub"><i class="bi bi-github" aria-hidden="true"></i></a>
+        </div>
+        <button class="btn btn-dark" id="themeSwitch"><i class="bi bi-moon"></i></button>
       </div>
       
     </header>
-    <div class="alert alert-info mx-auto">
-      <h2>Now open source!</h2>
-      <p>
-        Contributors can post game requests & list updates to the <a href="https://github.com/video-game-randomizers/rando-list">GitHub repository</a>.
-      </p>
-      <a href="https://www.debigare.com/the-future-of-the-video-game-randomizer-list/">Read the full announcement here!</a>
+    <div class="alert alert-info mx-auto d-flex">
+      <div class="pe-3 d-flex">
+        <i class="bi bi-info-circle my-auto mx-auto fs-2"></i>
+      </div>
+      <div>
+        <h2>Now open source!</h2>
+        <p>
+          Contributors can post game requests & list updates to the <a href="https://github.com/video-game-randomizers/rando-list">GitHub repository</a>.
+        </p>
+        <a href="https://www.debigare.com/the-future-of-the-video-game-randomizer-list/">Read the full announcement here!</a>
+      </div>
     </div>
     <div class="card mb-3">
       <div class="card-header d-flex justify-content-between">
-        <h2 id="recent-randomizers"><a href="#recent-randomizers">🔗</a> Recent List Updates</h2>
-        <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#recentUpdateBody" aria-expanded="false" aria-controls="recentUpdateBody">Collapse</button>
+        <h2 id="recent-randomizers" class="my-0"><a href="#recent-randomizers"><i class="bi bi-link-45deg"></i></a> Recent List Updates</h2>
+        <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#recentUpdateBody" aria-expanded="false" aria-controls="recentUpdateBody" aria-label="Collapse">
+          <i class="bi bi-arrows-collapse" aria-hidden="true"></i>
+        </button>
       </div>
       <div class="collapse show" id="recentUpdateBody">
         <div class="card-body">
@@ -58,7 +68,7 @@
 
     <div class="card">
       <div class="card-header">
-        <h2 id="all-randomizers"><a href="#all-randomizers">🔗</a> All Randomizers</h2>
+        <h2 id="all-randomizers" class="my-0"><a href="#all-randomizers"><i class="bi bi-link-45deg"></i></a> All Randomizers</h2>
       </div>
       <div class="thebiglist">
         {% include list.html series=site.data %}
@@ -120,6 +130,10 @@
       </div>
     </div>
 
+    <script
+    src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
+    integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8="
+    crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="assets/index.js">
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -32,8 +32,8 @@
       <div class="d-flex justify-content-center gap-2">
         <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#aboutModal"><i class="bi bi-info-circle"></i> About</button>
         <div class="btn-group" role="group" aria-label="External Links">
-          <a class="btn btn-outline-success" href="https://discord.com/invite/YREMzGQ3gd" aria-label="Discord"><i class="bi bi-discord" aria-hidden="true"></i></a>
-          <a class="btn btn-outline-success" href="https://github.com/video-game-randomizers/rando-list" aria-label="GitHub"><i class="bi bi-github" aria-hidden="true"></i></a>
+          <a class="btn btn-outline-success" href="https://discord.com/invite/YREMzGQ3gd" aria-label="Discord"><i class="bi bi-discord" aria-hidden="true"></i> Discord</a>
+          <a class="btn btn-outline-success" href="https://github.com/video-game-randomizers/rando-list" aria-label="GitHub"><i class="bi bi-github" aria-hidden="true"></i> GitHub</a>
         </div>
         <button class="btn btn-dark" id="themeSwitch"><i class="bi bi-moon"></i></button>
       </div>


### PR DESCRIPTION
Adds icons for socials & replaces the somewhat ugly [🔗](link) prefix with a simple icon.

Also modifies the theme switch toggle to a sun/moon in the opposite theme.


This PR adds dependencies on [Bootstrap-Icons](https://icons.getbootstrap.com/) (which feels reasonable as it is heavily integrated with Bootstrap & not unreasonably large) and JQuery to keep script complexity to a minimum.