### PR TITLE
templates cleanup

### DIFF
--- a/src/_includes/game.html
+++ b/src/_includes/game.html
@@ -1,58 +1,44 @@
 {%- assign game_data = include.series.games[include.game] -%}
 
-{%- assign randos = "" | split: "" -%}
-{%- for rando in include.series.randomizers -%}
-    {%- assign matched = false -%}
+{%- assign randos = include.series.randomizers | where_exp:"r","r.games contains include.game" -%}
 
-    {%- for g in rando.games -%}
-        {%- if g == include.game -%}
-            {%- assign matched = true -%}
+{%- if randos.size > 0 -%}
+
+    {%- unless include.notitle -%}
+    <h4>
+        {{ include.game }}
+        {%- if game_data.release-date -%}
+            {%- assign release_year = game_data.release-date | split: "-" | first -%}
+            ({{ release_year }})
         {%- endif -%}
+    </h4>
+    {%- endunless -%}
+
+    <p>
+        {%- if game_data.sub-series -%}
+            {{ game_data.sub-series }}
+            {% if game_data.genres.size > 0 || game_data.platforms.size > 0 %}
+            | 
+            {% endif %}
+        {%- endif -%}
+        {{ game_data.genres | join: ", " }}
+        {% if game_data.genres.size > 0 && game_data.platforms.size > 0 %}
+        | 
+        {% endif %}
+        {{ game_data.platforms | join: ", " }}
+    </p>
+
+    {%- if game_data.comment -%}
+        <p>{{ game_data.comment | markdownify }}</p>
+    {%- endif -%}
+
+    <ul class="game-list">
+
+    {%- assign randos = randos | sort_natural: "identifier" -%}
+    {%- for rando in randos -%}
+        {%- include rando.html rando=rando parent_name=include.game -%}
     {%- endfor -%}
 
-    {%- if matched == false -%}
-        {%- continue -%}
-    {%- endif -%}
+    </ul>
 
-    {%- assign randos = randos | push: rando -%}
-{%- endfor -%}
-
-{%- if randos.size == 0 -%}
-    {%- continue -%}
 {%- endif -%}
-
-{%- unless include.notitle -%}
-<h4>
-    {{ include.game }}
-    {%- if game_data.release-date -%}
-        {%- assign release_year = game_data.release-date | split: "-" | first -%}
-        ({{ release_year }})
-    {%- endif -%}
-</h4>
-{%- endunless -%}
-<p>
-    {%- if game_data.sub-series -%}
-        {{ game_data.sub-series }}
-        {% if game_data.genres.size > 0 || game_data.platforms.size > 0 %}
-         | 
-        {% endif %}
-    {%- endif -%}
-    {{ game_data.genres | join: ", " }}
-    {% if game_data.genres.size > 0 && game_data.platforms.size > 0 %}
-     | 
-    {% endif %}
-    {{ game_data.platforms | join: ", " }}
-</p>
-
-{%- if game_data.comment -%}
-    <p>{{ game_data.comment | markdownify }}</p>
-{%- endif -%}
-
-<ul class="game-list">
-
-{%- assign randos = randos | sort_natural: "identifier" -%}
-{%- for rando in randos -%}
-    {%- include rando.html rando=rando parent_name=include.game -%}
-{%- endfor -%}
-
-</ul>

--- a/src/_includes/rando.html
+++ b/src/_includes/rando.html
@@ -1,9 +1,10 @@
 {%- assign rando = include.rando -%}
-<li class="rando" id="{{ include.parent_name }}-{{ rando.identifier }}">
+<li class="rando" id="{{ include.parent_name | cgi_escape }}-{{ rando.identifier | cgi_escape }}">
     <h5><a href="{{ rando.url }}">{{ rando.identifier }}</a></h5>
 
     {%- if include.standalone -%}
-        <ul>{% for game in rando.games %}
+        {%- assign games = rando.games | sort_natural -%}
+        <ul>{% for game in games %}
             <li>{{ game }}</li>
         {% endfor %}
         </ul>

--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -4,55 +4,42 @@
 {%- endfor -%}
 {%- assign games = games | sort_natural -%}
 
-{%- assign seriesText = include.series.name -%}
-{%- assign firstGame = nil -%}
-{%- if games.size == 1 -%}
-    {%- assign firstGame = games[0] -%}
-    {%- comment -%} Series with a different name to the sole game within will have their title appended {%- endcomment -%}
-    {%- if firstGame != seriesText -%}
-        {%- assign series_suffix = ' <span class="text-muted">(SERIES)</span>' | replace: "SERIES", seriesText -%}
-    {%- else -%}
-        {%- assign series_suffix = null -%}
-    {%- endif -%}
+<h3 id="{{ include.series.name | cgi_escape }}" class="my-0"><a href="#{{ include.series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
+    {% if games.size == 1 %}
+        {%- assign no_game_titles = true -%}
+        {%- assign firstGame = games[0] -%}
+        {%- assign game_data = include.series.games[firstGame] -%}
+        {%- assign release_year = game_data.release-date | split: "-" | first -%}
 
-    {%- comment -%} Add release date to game listed if present {%- endcomment -%}
-    {%- assign game_data = include.series.games[firstGame] -%}
-    {%- assign release_year = game_data.release-date | split: "-" | first -%}
-    {%- if release_year != null -%}
-        {%- assign release_year_suffix = ' <span class="text-muted fs-5">(RELEASE)</span>' | replace: "RELEASE", release_year -%}
-    {%- else -%}
-        {%- assign release_year_suffix = null -%}
-    {%- endif -%}
-
-    {%- assign seriesText = firstGame | append: release_year_suffix | append: series_suffix -%}
-{%- endif -%}
-
-<h3 id="{{ include.series.name }}" class="my-0"><a href="#{{ include.series.name }}"><i class="bi bi-link-45deg"></i></a> {{ seriesText }}</h3>
-
+        {{ firstGame }}
+        {% if release_year %}
+            <span class="text-muted fs-5">({{ release_year }})</span>
+        {% endif %}
+        
+        {%- comment -%} Series with a different name to the sole game within will have their title appended {%- endcomment -%}
+        {% if firstGame != include.series.name %}
+            <span class="text-muted">{{ include.series.name }}</span>
+        {% endif %}
+    {% else %}
+        {{ include.series.name }}
+    {% endif %}
+</h3>
 
 {%- if include.series.comment -%}
     <p>{{ include.series.comment | markdownify }}</p>
 {%- endif -%}
 
-
 <ul class="series-list">
 {%- if include.games_merged -%}
-    {%- assign randos = "" | split: "" -%}
-    {%- for rando in include.series.randomizers -%}
-        {%- assign randos = randos | push: rando -%}
-    {%- endfor -%}
-    {%- assign randos = randos | sort_natural: "identifier" -%}
+    {%- assign randos = include.series.randomizers | sort_natural: "identifier" -%}
 
     {%- for rando in randos -%}
         {%- include rando.html rando=rando parent_name=include.series.name standalone=true -%}
     {%- endfor -%}
+
 {%- else -%}
-    {%- if firstGame -%}
-        {%- include game.html series=include.series game=firstGame notitle=true -%}
-    {%- else -%}
-        {%- for game in games -%}
-            {%- include game.html series=include.series game=game -%}
-        {%- endfor -%}
-    {%- endif -%}
+    {%- for game in games -%}
+        {%- include game.html series=include.series game=game notitle=no_game_titles -%}
+    {%- endfor -%}
 {%- endif -%}
 </ul>

--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -3,6 +3,7 @@
     {%- assign games = games | push: game[0] -%}
 {%- endfor -%}
 {%- assign games = games | sort_natural -%}
+{%- assign no_game_titles = false -%}
 
 <h3 id="{{ include.series.name | cgi_escape }}" class="my-0"><a href="#{{ include.series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
     {% if games.size == 1 %}


### PR DESCRIPTION
## Description

Cleanup of templates. Some better usage of filters like `where_exp`. `cgi_escape` for IDs.

Also removed `continue` statement inside of `game.html` which assumed it was being included inside of a for loop.

And inside `rando.html` fixed the standalone games list not being sorted.

If you merge https://github.com/video-game-randomizers/rando-list/pull/32 then you don't need to review this one,