### PR TITLE
Multi-game randos displayed separately

### DIFF
--- a/src/_includes/game.html
+++ b/src/_includes/game.html
@@ -1,44 +1,30 @@
+
 {%- assign game_data = include.series.games[include.game] -%}
 
-{%- assign randos = include.series.randomizers | where_exp:"r","r.games contains include.game" -%}
-
-{%- if randos.size > 0 -%}
-
-    {%- unless include.notitle -%}
-    <h4>
-        {{ include.game }}
-        {%- if game_data.release-date -%}
-            {%- assign release_year = game_data.release-date | split: "-" | first -%}
-            ({{ release_year }})
-        {%- endif -%}
-    </h4>
-    {%- endunless -%}
-
-    <p>
-        {%- if game_data.sub-series -%}
-            {{ game_data.sub-series }}
-            {% if game_data.genres.size > 0 || game_data.platforms.size > 0 %}
-            | 
-            {% endif %}
-        {%- endif -%}
-        {{ game_data.genres | join: ", " }}
-        {% if game_data.genres.size > 0 && game_data.platforms.size > 0 %}
-        | 
-        {% endif %}
-        {{ game_data.platforms | join: ", " }}
-    </p>
-
-    {%- if game_data.comment -%}
-        <p>{{ game_data.comment | markdownify }}</p>
+{%- unless include.notitle -%}
+<h4>
+    {{ include.game }}
+    {%- if game_data.release-date -%}
+        {%- assign release_year = game_data.release-date | split: "-" | first -%}
+        ({{ release_year }})
     {%- endif -%}
+</h4>
+{%- endunless -%}
 
-    <ul class="game-list">
+<p>
+    {%- if game_data.sub-series -%}
+        {{ game_data.sub-series }}
+        {% if game_data.genres.size > 0 || game_data.platforms.size > 0 %}
+            | 
+        {% endif %}
+    {%- endif -%}
+    {{ game_data.genres | join: ", " }}
+    {% if game_data.genres.size > 0 && game_data.platforms.size > 0 %}
+        | 
+    {% endif %}
+    {{ game_data.platforms | join: ", " }}
+</p>
 
-    {%- assign randos = randos | sort_natural: "identifier" -%}
-    {%- for rando in randos -%}
-        {%- include rando.html rando=rando parent_name=include.game -%}
-    {%- endfor -%}
-
-    </ul>
-
+{%- if game_data.comment -%}
+    <p>{{ game_data.comment | markdownify }}</p>
 {%- endif -%}

--- a/src/_includes/game.html
+++ b/src/_includes/game.html
@@ -1,58 +1,44 @@
 {%- assign game_data = include.series.games[include.game] -%}
 
-{%- assign randos = "" | split: "" -%}
-{%- for rando in include.series.randomizers -%}
-    {%- assign matched = false -%}
+{%- assign randos = include.series.randomizers | where_exp:"r","r.games contains include.game" -%}
 
-    {%- for g in rando.games -%}
-        {%- if g == include.game -%}
-            {%- assign matched = true -%}
+{%- if randos.size > 0 -%}
+
+    {%- unless include.notitle -%}
+    <h4>
+        {{ include.game }}
+        {%- if game_data.release-date -%}
+            {%- assign release_year = game_data.release-date | split: "-" | first -%}
+            ({{ release_year }})
         {%- endif -%}
+    </h4>
+    {%- endunless -%}
+
+    <p>
+        {%- if game_data.sub-series -%}
+            {{ game_data.sub-series }}
+            {% if game_data.genres.size > 0 || game_data.platforms.size > 0 %}
+            | 
+            {% endif %}
+        {%- endif -%}
+        {{ game_data.genres | join: ", " }}
+        {% if game_data.genres.size > 0 && game_data.platforms.size > 0 %}
+        | 
+        {% endif %}
+        {{ game_data.platforms | join: ", " }}
+    </p>
+
+    {%- if game_data.comment -%}
+        <p>{{ game_data.comment | markdownify }}</p>
+    {%- endif -%}
+
+    <ul class="game-list">
+
+    {%- assign randos = randos | sort_natural: "identifier" -%}
+    {%- for rando in randos -%}
+        {%- include rando.html rando=rando parent_name=include.game -%}
     {%- endfor -%}
 
-    {%- if matched == false -%}
-        {%- continue -%}
-    {%- endif -%}
+    </ul>
 
-    {%- assign randos = randos | push: rando -%}
-{%- endfor -%}
-
-{%- if randos.size == 0 -%}
-    {%- continue -%}
 {%- endif -%}
-
-{%- unless include.notitle -%}
-<h4>
-    {{ include.game }}
-    {%- if game_data.release-date -%}
-        {%- assign release_year = game_data.release-date | split: "-" | first -%}
-        ({{ release_year }})
-    {%- endif -%}
-</h4>
-{%- endunless -%}
-<p>
-    {%- if game_data.sub-series -%}
-        {{ game_data.sub-series }}
-        {% if game_data.genres.size > 0 || game_data.platforms.size > 0 %}
-         | 
-        {% endif %}
-    {%- endif -%}
-    {{ game_data.genres | join: ", " }}
-    {% if game_data.genres.size > 0 && game_data.platforms.size > 0 %}
-     | 
-    {% endif %}
-    {{ game_data.platforms | join: ", " }}
-</p>
-
-{%- if game_data.comment -%}
-    <p>{{ game_data.comment | markdownify }}</p>
-{%- endif -%}
-
-<ul class="game-list">
-
-{%- assign randos = randos | sort_natural: "identifier" -%}
-{%- for rando in randos -%}
-    {%- include rando.html rando=rando parent_name=include.game -%}
-{%- endfor -%}
-
-</ul>

--- a/src/_includes/list.html
+++ b/src/_includes/list.html
@@ -19,6 +19,8 @@
     {%- include series.html series=series -%}
     </li>
 {%- endfor -%}
-</ul>
 
+<li class="list-group-item">
 {%- include series.html series=site.data.Multi-series games_merged=true -%}
+</li>
+</ul>

--- a/src/_includes/list.html
+++ b/src/_includes/list.html
@@ -14,13 +14,13 @@
 {%- assign series_sorted = series_sorted | sort_natural: "name" -%}
 
 <ul class="list-group list-group-flush">
-{%- for series in series_sorted -%}
-    <li class="list-group-item">
-    {%- include series.html series=series -%}
-    </li>
-{%- endfor -%}
+    {%- for series in series_sorted -%}
+        <li class="list-group-item">
+            {%- include series.html series=series -%}
+        </li>
+    {%- endfor -%}
 
-<li class="list-group-item">
-{%- include series.html series=site.data.Multi-series games_merged=true -%}
-</li>
+    <li class="list-group-item">
+    {%- include series.html series=site.data.Multi-series games_merged=true -%}
+    </li>
 </ul>

--- a/src/_includes/rando.html
+++ b/src/_includes/rando.html
@@ -2,9 +2,10 @@
 <li class="rando" id="{{ include.parent_name | cgi_escape }}-{{ rando.identifier | cgi_escape }}">
     <h5><a href="{{ rando.url }}">{{ rando.identifier }}</a></h5>
 
-    {%- if include.standalone -%}
-        {%- assign games = rando.games | sort_natural -%}
-        <ul>{% for game in games %}
+    {%- if include.showgames -%}
+        {%- assign randogames = rando.games | sort_natural -%}
+        <ul>
+        {% for game in randogames %}
             <li>{{ game }}</li>
         {% endfor %}
         </ul>

--- a/src/_includes/rando.html
+++ b/src/_includes/rando.html
@@ -1,9 +1,10 @@
 {%- assign rando = include.rando -%}
-<li class="rando" id="{{ include.parent_name }}-{{ rando.identifier }}">
+<li class="rando" id="{{ include.parent_name | cgi_escape }}-{{ rando.identifier | cgi_escape }}">
     <h5><a href="{{ rando.url }}">{{ rando.identifier }}</a></h5>
 
     {%- if include.standalone -%}
-        <ul>{% for game in rando.games %}
+        {%- assign games = rando.games | sort_natural -%}
+        <ul>{% for game in games %}
             <li>{{ game }}</li>
         {% endfor %}
         </ul>

--- a/src/_includes/randos_list.html
+++ b/src/_includes/randos_list.html
@@ -1,0 +1,6 @@
+<ul class="randos-list">
+    {%- assign randos = include.randos | sort_natural: "identifier" -%}
+    {%- for rando in randos -%}
+        {%- include rando.html rando=rando parent_name=include.parent_name showgames=include.showgames -%}
+    {%- endfor -%}
+</ul>

--- a/src/_includes/recents.html
+++ b/src/_includes/recents.html
@@ -21,14 +21,14 @@
 <ul class="recents-list list-group list-group-flush">
 {%- for rando in randos -%}
     <li class="list-group-item">
-    {%- if prev_updated != rando.updated-date -%}
-    {%- assign prev_updated = rando.updated-date -%}
-        <h3>Updated {{ prev_updated }}</h3>
-    {%- endif -%}
-    
-    <ul>
-    {%- include rando.html rando=rando parent_name="recents" standalone=true -%}
-    </ul>
+        {%- if prev_updated != rando.updated-date -%}
+            {%- assign prev_updated = rando.updated-date -%}
+            <h3>Updated {{ prev_updated }}</h3>
+        {%- endif -%}
+        
+        <ul>
+        {%- include rando.html rando=rando parent_name="recents" showgames=true -%}
+        </ul>
     </li>
 {%- endfor -%}
 </ul>

--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -4,55 +4,42 @@
 {%- endfor -%}
 {%- assign games = games | sort_natural -%}
 
-{%- assign seriesText = include.series.name -%}
-{%- assign firstGame = nil -%}
-{%- if games.size == 1 -%}
-    {%- assign firstGame = games[0] -%}
-    {%- comment -%} Series with a different name to the sole game within will have their title appended {%- endcomment -%}
-    {%- if firstGame != seriesText -%}
-        {%- assign series_suffix = ' <span class="text-muted">(SERIES)</span>' | replace: "SERIES", seriesText -%}
-    {%- else -%}
-        {%- assign series_suffix = null -%}
-    {%- endif -%}
+<h3 id="{{ include.series.name | cgi_escape }}" class="my-0"><a href="#{{ include.series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
+    {% if games.size == 1 %}
+        {%- assign no_game_titles = true -%}
+        {%- assign firstGame = games[0] -%}
+        {%- assign game_data = include.series.games[firstGame] -%}
+        {%- assign release_year = game_data.release-date | split: "-" | first -%}
 
-    {%- comment -%} Add release date to game listed if present {%- endcomment -%}
-    {%- assign game_data = include.series.games[firstGame] -%}
-    {%- assign release_year = game_data.release-date | split: "-" | first -%}
-    {%- if release_year != null -%}
-        {%- assign release_year_suffix = ' <span class="text-muted fs-5">(RELEASE)</span>' | replace: "RELEASE", release_year -%}
-    {%- else -%}
-        {%- assign release_year_suffix = null -%}
-    {%- endif -%}
-
-    {%- assign seriesText = firstGame | append: release_year_suffix | append: series_suffix -%}
-{%- endif -%}
-
-<h3 id="{{ include.series.name }}" class="my-0"><a href="#{{ include.series.name }}"><i class="bi bi-link-45deg"></i></a> {{ seriesText }}</h3>
-
+        {{ firstGame }}
+        {% if release_year %}
+            <span class="text-muted fs-5">({{ release_year }})</span>
+        {% endif %}
+        
+        {%- comment -%} Series with a different name to the sole game within will have their title appended {%- endcomment -%}
+        {% if firstGame != include.series.name %}
+            <span class="text-muted">{{ include.series.name }}</span>
+        {% endif %}
+    {% else %}
+        {{ include.series.name }}
+    {% endif %}
+</h3>
 
 {%- if include.series.comment -%}
     <p>{{ include.series.comment | markdownify }}</p>
 {%- endif -%}
 
-
 <ul class="series-list">
 {%- if include.games_merged -%}
-    {%- assign randos = "" | split: "" -%}
-    {%- for rando in include.series.randomizers -%}
-        {%- assign randos = randos | push: rando -%}
-    {%- endfor -%}
-    {%- assign randos = randos | sort_natural: "identifier" -%}
+    {%- assign randos = include.series.randomizers | sort_natural: "identifier" -%}
 
     {%- for rando in randos -%}
         {%- include rando.html rando=rando parent_name=include.series.name standalone=true -%}
     {%- endfor -%}
+
 {%- else -%}
-    {%- if firstGame -%}
-        {%- include game.html series=include.series game=firstGame notitle=true -%}
-    {%- else -%}
-        {%- for game in games -%}
-            {%- include game.html series=include.series game=game -%}
-        {%- endfor -%}
-    {%- endif -%}
+    {%- for game in games -%}
+        {%- include game.html series=include.series game=game notitle=no_game_titles -%}
+    {%- endfor -%}
 {%- endif -%}
 </ul>

--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -1,3 +1,4 @@
+{%- assign series = include.series -%}
 {%- assign games = "" | split: "" -%}
 {%- for game in include.series.games -%}
     {%- assign games = games | push: game[0] -%}
@@ -5,11 +6,11 @@
 {%- assign games = games | sort_natural -%}
 {%- assign no_game_titles = false -%}
 
-<h3 id="{{ include.series.name | cgi_escape }}" class="my-0"><a href="#{{ include.series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
+<h3 id="{{ series.name | cgi_escape }}" class="my-0"><a href="#{{ series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
     {% if games.size == 1 %}
         {%- assign no_game_titles = true -%}
         {%- assign firstGame = games[0] -%}
-        {%- assign game_data = include.series.games[firstGame] -%}
+        {%- assign game_data = series.games[firstGame] -%}
         {%- assign release_year = game_data.release-date | split: "-" | first -%}
 
         {{ firstGame }}
@@ -18,29 +19,22 @@
         {% endif %}
         
         {%- comment -%} Series with a different name to the sole game within will have their title appended {%- endcomment -%}
-        {% if firstGame != include.series.name %}
-            <span class="text-muted">{{ include.series.name }}</span>
+        {% if firstGame != series.name %}
+            <span class="text-muted">{{ series.name }}</span>
         {% endif %}
     {% else %}
-        {{ include.series.name }}
+        {{ series.name }}
     {% endif %}
 </h3>
 
-{%- if include.series.comment -%}
-    <p>{{ include.series.comment | markdownify }}</p>
+{%- if series.comment -%}
+    <p>{{ series.comment | markdownify }}</p>
 {%- endif -%}
 
 <ul class="series-list">
 {%- if include.games_merged -%}
-    {%- assign randos = include.series.randomizers | sort_natural: "identifier" -%}
-
-    {%- for rando in randos -%}
-        {%- include rando.html rando=rando parent_name=include.series.name standalone=true -%}
-    {%- endfor -%}
-
+    {%- include randos_list.html randos=series.randomizers parent_name=series.name showgames=true -%}
 {%- else -%}
-    {%- for game in games -%}
-        {%- include game.html series=include.series game=game notitle=no_game_titles -%}
-    {%- endfor -%}
+    {%- include series_games.html series=series -%}
 {%- endif -%}
 </ul>

--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -3,6 +3,7 @@
     {%- assign games = games | push: game[0] -%}
 {%- endfor -%}
 {%- assign games = games | sort_natural -%}
+{%- assign no_game_titles = false -%}
 
 <h3 id="{{ include.series.name | cgi_escape }}" class="my-0"><a href="#{{ include.series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
     {% if games.size == 1 %}

--- a/src/_includes/series.html
+++ b/src/_includes/series.html
@@ -4,11 +4,9 @@
     {%- assign games = games | push: game[0] -%}
 {%- endfor -%}
 {%- assign games = games | sort_natural -%}
-{%- assign no_game_titles = false -%}
 
 <h3 id="{{ series.name | cgi_escape }}" class="my-0"><a href="#{{ series.name | cgi_escape }}"><i class="bi bi-link-45deg"></i></a>
     {% if games.size == 1 %}
-        {%- assign no_game_titles = true -%}
         {%- assign firstGame = games[0] -%}
         {%- assign game_data = series.games[firstGame] -%}
         {%- assign release_year = game_data.release-date | split: "-" | first -%}

--- a/src/_includes/series_games.html
+++ b/src/_includes/series_games.html
@@ -1,0 +1,28 @@
+{%- assign series = include.series -%}
+{%- assign multirandos = series.randomizers | where_exp:"r", "r.games.size >= 3" -%}
+
+{%- assign cutoff = series.randomizers.size | minus: 2 -%}
+{%- if multirandos.size > 0 and multirandos.size > cutoff -%}
+    {%- assign multirandos = series.randomizers -%}
+{%- elsif multirandos.size > 0 -%}
+    <h4>Multi-Game Randomizers</h4>
+{%- endif -%}
+
+{%- if multirandos.size > 0 -%}
+    {%- include randos_list.html series=series parent_name=series.name randos=multirandos showgames=true -%}
+{%- endif -%}
+
+{%- if multirandos.size < series.randomizers.size -%}
+    {%- assign no_game_titles = false -%}
+    {%- if games.size == 1 -%}{%- assign no_game_titles = true -%}{%- endif -%}
+
+    {%- for game in games -%}
+        {%- assign randos = series.randomizers | where_exp:"r", "r.games.size < 3" | where_exp:"r","r.games contains game" -%}
+        {%- if randos.size == 0 -%}
+            {%- continue -%}
+        {%- endif -%}
+
+        {%- include game.html series=series game=game notitle=no_game_titles -%}
+        {%- include randos_list.html series=series parent_name=game randos=randos -%}
+    {%- endfor -%}
+{%- endif -%}


### PR DESCRIPTION
## Description

Pull the multi-game randomizers out of the game groups so that they don't get displayed so many times. Based on https://github.com/video-game-randomizers/rando-list/pull/31 so if you merge this one you don't need to review that one.

partially helps #29 (pokemon needs fixes in its yml file too)

![image](https://github.com/user-attachments/assets/14b1429f-ffa8-4a37-abf6-749e0741a7bc)

![image](https://github.com/user-attachments/assets/ea60916d-0514-404e-9280-8f521df0d9d1)

If we also want to do grouping by sub-series, it could become a bit complicated, or maybe users will get confused with the variations of formatting (grouped by game, grouped by sub-series, grouped by game and sub-series, multi-games together, ungrouped)

This also means if a game is only represented by multi-game randomizers, then the tags for the game are not displayed (release year, platforms, genres, sub-series)