### PR TITLE
(Pokémon) updates to UPR branches:

### DIFF
--- a/src/series/Pokemon.yml
+++ b/src/series/Pokemon.yml
@@ -221,15 +221,30 @@ randomizers:
     - (VII) Gen VII primary & secondary
     identifier: Universal Pokemon Randomizer ZX
     url: https://github.com/Ajarmar/universal-pokemon-randomizer-zx
+    obsolete: true
     updated-date: 1900-01-01
     added-date: 1900-01-01
 -   games:
+    - (I-VII) Gens I to VI all
+    - (VII) Gen VII primary & secondary
+    identifier: Universal Pokemon Randomizer ZX (Ironhidelvan's)
+    url: https://github.com/IronhideIvan/universal-pokemon-randomizer-zx
+    updated-date: 2024-09-08
+    added-date: 2024-09-08
+-   games:
+    - (I-VII) Gens I to VI all
+    - (VII) Gen VII primary & secondary
+    identifier: Universal Pokemon Randomizer FVX
+    url: https://github.com/upr-fvx/universal-pokemon-randomizer-fvx
+    updated-date: 2024-09-08
+    added-date: 2024-09-08
+-   games:
     - (I-V) Gens I to V all
-    identifier: voliol's Universal Pokemon Randomizer ZX
-    url: https://github.com/voliol/universal-pokemon-randomizer
-    opensource: true
-    updated-date: 2024-07-11
-    added-date: 2024-07-11
+    identifier: Universal Pokemon Randomizer (brentspector's)
+    url: https://github.com/brentspector/universal-pokemon-randomizer
+    obsolete: true
+    updated-date: 2024-09-08
+    added-date: 2024-09-08
 -   games:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer

--- a/src/series/Pokemon.yml
+++ b/src/series/Pokemon.yml
@@ -229,22 +229,22 @@ randomizers:
     - (VII) Gen VII primary & secondary
     identifier: Universal Pokemon Randomizer ZX (Ironhidelvan's)
     url: https://github.com/IronhideIvan/universal-pokemon-randomizer-zx
-    updated-date: 2024-09-08
-    added-date: 2024-09-08
+    updated-date: 2024-09-09
+    added-date: 2024-09-09
 -   games:
     - (I-VII) Gens I to VI all
     - (VII) Gen VII primary & secondary
     identifier: Universal Pokemon Randomizer FVX
     url: https://github.com/upr-fvx/universal-pokemon-randomizer-fvx
-    updated-date: 2024-09-08
-    added-date: 2024-09-08
+    updated-date: 2024-09-09
+    added-date: 2024-09-09
 -   games:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer (brentspector's)
     url: https://github.com/brentspector/universal-pokemon-randomizer
     obsolete: true
-    updated-date: 2024-09-08
-    added-date: 2024-09-08
+    updated-date: 2024-09-09
+    added-date: 2024-09-09
 -   games:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer


### PR DESCRIPTION
add UPR FVX, Ironhidelvan's, brentspector's; remove voliol's; mark ZX as obsolete

Main branch ZX is marked obsolete in favor of FVX and Ironhidelvan's branch. voliol's is removed since it is too similar to FVX and adds clutter. Though the List contains multiple versions of the Universal Pokemon Randomizer, these are either different branches of development with different sets of features (e.g. ZX and the Gaia fork) or represent a change in who is developing it (e.g. original UPR -> ZX -> Ironhidelvan's). FVX is a merging of voliol's and the foxoftheasterisk's branches, with the two developers of said branches continuing FVX. foxoftheasterisk's has never been listed in the List. That said, the alternative to removing voliol's, would be to mark voliol's as obsolete and also add foxoftheasterisk's to the List - already marked obsolete! I do not believe that is a preferable solution, since neither branch contains features not contained in FVX.

Below is a graph of branches of the UPR, as I understand it. Branches represented are the ones (once) in the List, as well as foxoftheasterisk's. 
```
0-\-->1-\->5--->8
  \-->2	\->6-/
  \-->3	\->7
  \-->4
```

0: the original UPR
1: ZX
2: brentspector's
3: Gaia fork
4: speedchoice randomizer(s)
5: voliol's
6: foxoftheasterisk's
7: Ironhidelvan's
8: FVX

## Description

<!--
Please describe exactly what this PR changes.
If it fixes an issue, add "Fixes #XXXX"

If you're making changes to the yaml data, it's a good idea to run the schemaCheck.py yourself and make sure everything passes before submitting the pull request. You can also paste the yaml code into a validator website if that's easier for you, such as https://jsonformatter.org/yaml-validator

If you're making changes to html code, it's a good idea to run the Jekyll build yourself and make sure the output looks good.
-->
