### PR TITLE
Fix Universal Pokémon Randomizer (brentspector's) being marked as obsolete

### DIFF
--- a/src/series/Pokemon.yml
+++ b/src/series/Pokemon.yml
@@ -242,7 +242,6 @@ randomizers:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer (brentspector's)
     url: https://github.com/brentspector/universal-pokemon-randomizer
-    obsolete: true
     updated-date: 2024-09-09
     added-date: 2024-09-09
 -   games:

--- a/src/series/Pokemon.yml
+++ b/src/series/Pokemon.yml
@@ -221,15 +221,30 @@ randomizers:
     - (VII) Gen VII primary & secondary
     identifier: Universal Pokemon Randomizer ZX
     url: https://github.com/Ajarmar/universal-pokemon-randomizer-zx
+    obsolete: true
     updated-date: 1900-01-01
     added-date: 1900-01-01
 -   games:
+    - (I-VII) Gens I to VI all
+    - (VII) Gen VII primary & secondary
+    identifier: Universal Pokemon Randomizer ZX (Ironhidelvan's)
+    url: https://github.com/IronhideIvan/universal-pokemon-randomizer-zx
+    updated-date: 2024-09-08
+    added-date: 2024-09-08
+-   games:
+    - (I-VII) Gens I to VI all
+    - (VII) Gen VII primary & secondary
+    identifier: Universal Pokemon Randomizer FVX
+    url: https://github.com/upr-fvx/universal-pokemon-randomizer-fvx
+    updated-date: 2024-09-08
+    added-date: 2024-09-08
+-   games:
     - (I-V) Gens I to V all
-    identifier: voliol's Universal Pokemon Randomizer ZX
-    url: https://github.com/voliol/universal-pokemon-randomizer
-    opensource: true
-    updated-date: 2024-07-11
-    added-date: 2024-07-11
+    identifier: Universal Pokemon Randomizer (brentspector's)
+    url: https://github.com/brentspector/universal-pokemon-randomizer
+    obsolete: true
+    updated-date: 2024-09-08
+    added-date: 2024-09-08
 -   games:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer

--- a/src/series/Pokemon.yml
+++ b/src/series/Pokemon.yml
@@ -229,22 +229,22 @@ randomizers:
     - (VII) Gen VII primary & secondary
     identifier: Universal Pokemon Randomizer ZX (Ironhidelvan's)
     url: https://github.com/IronhideIvan/universal-pokemon-randomizer-zx
-    updated-date: 2024-09-08
-    added-date: 2024-09-08
+    updated-date: 2024-09-09
+    added-date: 2024-09-09
 -   games:
     - (I-VII) Gens I to VI all
     - (VII) Gen VII primary & secondary
     identifier: Universal Pokemon Randomizer FVX
     url: https://github.com/upr-fvx/universal-pokemon-randomizer-fvx
-    updated-date: 2024-09-08
-    added-date: 2024-09-08
+    updated-date: 2024-09-09
+    added-date: 2024-09-09
 -   games:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer (brentspector's)
     url: https://github.com/brentspector/universal-pokemon-randomizer
     obsolete: true
-    updated-date: 2024-09-08
-    added-date: 2024-09-08
+    updated-date: 2024-09-09
+    added-date: 2024-09-09
 -   games:
     - (I-V) Gens I to V all
     identifier: Universal Pokemon Randomizer


### PR DESCRIPTION
## Description

Fixes Universal Pokémon Randomizer (brentspector's) being marked as obsolete. I have no idea why this pull requests reports containing 4 commits, to my knowledge the first 2 have already been accepted in an earlier pull request.

<!--
Please describe exactly what this PR changes.
If it fixes an issue, add "Fixes #XXXX"

If you're making changes to the yaml data, it's a good idea to run the schemaCheck.py yourself and make sure everything passes before submitting the pull request. You can also paste the yaml code into a validator website if that's easier for you, such as https://jsonformatter.org/yaml-validator

If you're making changes to html code, it's a good idea to run the Jekyll build yourself and make sure the output looks good.
-->
