### PR TITLE
Death's Door: add Shadu-Multiworld

### DIFF
--- a/src/series/Deaths_Door.yml
+++ b/src/series/Deaths_Door.yml
@@ -8,6 +8,7 @@ randomizers:
     - Death's Door
     identifier: dpinela's Item Randomizer
     url: https://github.com/dpinela/DeathsDoor.Randomizer
-    updated-date: 2024-06-02
+    multiworld: Shadu-Multiworld
+    updated-date: 2024-09-30
     added-date: 2024-06-02
 sub-series: []

--- a/src/series/Multi-series.yml
+++ b/src/series/Multi-series.yml
@@ -122,6 +122,10 @@ games:
         genres: []
         platforms: []
         sub-series: Connected worlds
+    Death's Door:
+        genres: []
+        platforms: []
+        sub-series: Connected worlds
     Doom (Ultimate):
         genres: []
         platforms: []
@@ -530,7 +534,7 @@ randomizers:
     identifier: Shadu's Multiworld
     url: https://github.com/Shadudev/HollowKnight.MultiWorld
     multiworld: Shadu-Multiworld
-    updated-date: 2024-05-29
+    updated-date: 2024-09-30
     added-date: 2024-05-29
 -   games:
     - 'Castlevania: Harmony of Dissonance'

--- a/src/series/Multi-series.yml
+++ b/src/series/Multi-series.yml
@@ -526,6 +526,7 @@ randomizers:
 -   games:
     - Hollow Knight
     - Haiku, the Robot
+    - Death's Door
     identifier: Shadu's Multiworld
     url: https://github.com/Shadudev/HollowKnight.MultiWorld
     multiworld: Shadu-Multiworld


### PR DESCRIPTION
## Description

Adds Shadu-Multiworld support to Dpinela's Item Randomizer for Death's Door. See https://github.com/dpinela/DeathsDoor.Randomizer/releases/tag/v1.4