### PR TITLE
Update link for Metroid Prime 3: Corruption

### DIFF
--- a/src/series/Metroid.yml
+++ b/src/series/Metroid.yml
@@ -341,7 +341,7 @@ randomizers:
     identifier: gollop's
     url: https://github.com/Schwork-Corruption/corruptovania
     comment: 'Fork of [Randovania](https://randovania.org) dedicated to Prime 3 support'
-    updated-date: 2024-10-20
+    updated-date: 2024-10-31
     added-date: 1900-01-01
 -   games:
     - Metroid Prime Hunters

--- a/src/series/Metroid.yml
+++ b/src/series/Metroid.yml
@@ -339,9 +339,9 @@ randomizers:
 -   games:
     - 'Metroid Prime 3: Corruption'
     identifier: gollop's
-    url: https://discord.com/invite/WWGcay6
-    comment: 'Discord account required - Located in the #corruption-general channel'
-    updated-date: 1900-01-01
+    url: https://github.com/Schwork-Corruption/corruptovania
+    comment: 'Fork of [Randovania](https://randovania.org) dedicated to Prime 3 support'
+    updated-date: 2024-10-20
     added-date: 1900-01-01
 -   games:
     - Metroid Prime Hunters


### PR DESCRIPTION
## Description

The randomizer for Metroid Prime 3: Corruption is now hosted on a fork of [Randovania](https://randovania.org) called [Corruptovania](https://github.com/Schwork-Corruption/corruptovania)
You will no longer need to join the discord to play it.