### PR TITLE
add Legend of Zelda Majoras Mask randomizer: 2ship2harkinian

### DIFF
--- a/src/series/The_Legend_of_Zelda.yml
+++ b/src/series/The_Legend_of_Zelda.yml
@@ -399,6 +399,13 @@ randomizers:
     added-date: 1900-01-01
 -   games:
     - 'The Legend of Zelda: Majora''s Mask'
+    identifier: 2 Ship 2 Harkinian
+    url: https://github.com/HarbourMasters/2ship2harkinian
+    comment: Unofficial PC port with bundled randomizer
+    updated-date: 2025-09-20
+    added-date: 2025-09-20
+-   games:
+    - 'The Legend of Zelda: Majora''s Mask'
     identifier: Beta Quest
     url: https://www.zeldacodes.org/challenges/beta-quest
     comment: Requires a cheat engine supporting Gecko codes

--- a/src/series/The_Legend_of_Zelda.yml
+++ b/src/series/The_Legend_of_Zelda.yml
@@ -402,8 +402,9 @@ randomizers:
     identifier: 2 Ship 2 Harkinian
     url: https://github.com/HarbourMasters/2ship2harkinian
     comment: Unofficial PC port with bundled randomizer
-    updated-date: 2025-09-20
-    added-date: 2025-09-20
+    opensource: True
+    updated-date: 2025-10-05
+    added-date: 2025-10-05
 -   games:
     - 'The Legend of Zelda: Majora''s Mask'
     identifier: Beta Quest


### PR DESCRIPTION
## Description
Fixes #86 
Adds `2 Ship 2 Harkinian`, the unofficial PC port of `The Legend of Zelda: Majora's Mask`, which has a built-in randomizer as-of version 2.0.0 of the project.

```shell
❯ python validate-schema.py
passed: 310 errored: 0
```