### PR TITLE
Add Paper Mario: The Thousand-Year Door: Open-World Randomizer

### DIFF
--- a/src/series/Mario.yml
+++ b/src/series/Mario.yml
@@ -273,6 +273,12 @@ randomizers:
     comment: Located under Tools as Miscellaneous Cheat Codes
     updated-date: 1900-01-01
     added-date: 1900-01-01
+    games:
+    - 'Paper Mario: The Thousand-Year Door'
+    identifier: jamesbrq's Open-World Randomizer
+    url: https://www.ttydrandomizer.com/
+    updated-date: 1900-01-01
+    added-date: 1900-01-01
 -   games:
     - Super Paper Mario
     identifier: Level Editor and Randomizer

--- a/src/series/Mario.yml
+++ b/src/series/Mario.yml
@@ -277,8 +277,8 @@ randomizers:
     - 'Paper Mario: The Thousand-Year Door'
     identifier: jamesbrq's Open-World Randomizer
     url: https://www.ttydrandomizer.com/
-    updated-date: 1900-01-01
-    added-date: 1900-01-01
+    updated-date: 2025-10-05
+    added-date: 2025-10-05
 -   games:
     - Super Paper Mario
     identifier: Level Editor and Randomizer

--- a/src/series/Mario.yml
+++ b/src/series/Mario.yml
@@ -277,6 +277,7 @@ randomizers:
     - 'Paper Mario: The Thousand-Year Door'
     identifier: jamesbrq's Open-World Randomizer
     url: https://www.ttydrandomizer.com/
+    multiworld: Archipelago
     updated-date: 2025-10-05
     added-date: 2025-10-05
 -   games:


### PR DESCRIPTION
## Description

Adds the new Open-World Randomizer for Paper Mario: TTYD, a web-based generator running off of the archipelago version v0.6.0 of the randomizer.

```
python validate-schema.py
passed: 310 errored: 0
```

