### PR TITLE
adding Shadowgate 64 item randomizer

### DIFF
--- a/src/series/Shadowgate.yml
+++ b/src/series/Shadowgate.yml
@@ -13,5 +13,5 @@ randomizers:
     identifier: Chaos Magic Edition item randomizer
     url: https://github.com/grendell/sg64rando
     opensource: true
-    updated-date: 2026-03-17
-    added-date: 2026-03-17
+    updated-date: 2026-05-04
+    added-date: 2026-05-04

--- a/src/series/Shadowgate.yml
+++ b/src/series/Shadowgate.yml
@@ -1,0 +1,17 @@
+name: Shadowgate
+sub-series: []
+games:
+    'Shadowgate 64: Trials of the Four Towers':
+        genres:
+        - Adventure
+        platforms:
+        - N64
+        release-date: 1999-06-09
+randomizers:
+-   games:
+    - 'Shadowgate 64: Trials of the Four Towers'
+    identifier: Chaos Magic Edition item randomizer
+    url: https://github.com/grendell/sg64rando
+    opensource: true
+    updated-date: 2026-03-17
+    added-date: 2026-03-17


### PR DESCRIPTION
Adding [Shadowgate 64:  Chaos Magic Edition item randomizer](https://github.com/grendell/sg64rando).
Completes https://github.com/video-game-randomizers/rando-list/issues/98.

```
% python validate-schema.py                       
passed: 313 errored: 0
```